### PR TITLE
Expose Underlying CXTranslationUnit

### DIFF
--- a/Sources/Clang/TranslationUnit.swift
+++ b/Sources/Clang/TranslationUnit.swift
@@ -275,6 +275,11 @@ public class TranslationUnit {
     return (0..<toks.count).flatMap { convertCursor(cursors[$0]) }
   }
 
+  /// Returns the underlying CXTranslationUnit value.
+  public func asClang() -> CXTranslationUnit {
+    return self.clang
+  }
+
   deinit {
     clang_disposeTranslationUnit(clang)
   }


### PR DESCRIPTION
Multiple functions can be performed on the translation unit but are not exposed (yet) (e.g: serializing the translation unit).