### PR TITLE
Introduce static library product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,10 @@ let package = Package(
     products: [
       .library(
         name: "Clang",
-        targets: ["Clang"])
+        targets: ["Clang"]),
+      .library(name: "ClangStatic",
+               type: .static,
+               targets: ["Clang"])
     ],
     dependencies: [ ],
     targets: [


### PR DESCRIPTION
This is particularly useful when creating standalone executables. Generated Xcode project doesn't support this AFAICS, but `swift build` handles it just right.